### PR TITLE
Update bblayers.conf after addition of phytool

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -9,6 +9,7 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-openembedded/meta-oe \
   ${BSPDIR}/sources/meta-openembedded/meta-python \
   ${BSPDIR}/sources/meta-openembedded/meta-webserver \
+  ${BSPDIR}/sources/meta-openembedded/meta-networking \
   ${BSPDIR}/sources/meta-qt5 \
   ${BSPDIR}/sources/meta-mainline-common \
   ${BSPDIR}/sources/meta-mainline-graphics \


### PR DESCRIPTION
Since the recipe for dh-image-demo was modified in order to include the package phytool that is contained in the layer meta-openembedded/meta-networking, i would advise to add it to the bblayers.conf file. Otherwise trying to compile the image with the default settings will result in an error.